### PR TITLE
同じ場所で旅レポートを複数保存できないように修正

### DIFF
--- a/app/Http/Controllers/API/TravelerController.php
+++ b/app/Http/Controllers/API/TravelerController.php
@@ -35,7 +35,15 @@ class TravelerController extends Controller
             if ($travel->count() == 0) {
                 throw new \Exception('permission denied');
             }
-            $travelId = $travel[0]->travel_id; 
+            $travelId = $travel[0]->travel_id;
+
+            // 同じ場所では旅レポートを複数保存できないようにする
+            $locations = Location::where('travel_id', $travelId)->select('lat', 'lon')->get();
+            foreach ($locations as $location) {
+                if ($location->lat == $lat && $location->lon == $lon) {
+                    throw new \Exception('same location');
+                }
+            }
 
             if(!isset($base64image)){
                 throw new \Exception('no image');


### PR DESCRIPTION
<!-- Create pull requestを押す前に上の Preview で確認してください！ -->
<!-- 各コメントの下に項目を書いていってください！ -->
## Issueへのリンク
<!-- https://docs.github.com/ja/issues/tracking-your-work-with-issues/creating-issues/linking-a-pull-request-to-an-issue#manually-linking-a-pull-request-to-an-issue -->
<!-- resolve: #Issue番号 -->
resolve: #31 

## やったこと
<!-- このプルリクで何をしたのか？ -->
同じ場所で旅レポートを保存しようとした場合にエラーを返す処理を実装

## 変更内容
<!-- UIの変更ならスクリーンショット
     APIの変更ならリクエストとレスポンス -->
同じ場所で旅レポートを保存するとエラーが返る

## 動作確認
<!-- どのような動作確認を行ったのか？結果はどうか？ -->
Postmanで動作確認を行った

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）（あれば。無いなら「なし」でOK）-->
なし

<!-- Create pull request を押す前に上の Preview で確認してください！ -->
<!-- 画像が大きい場合は img タグを使用して大きさを決めてください！ -->
## チェックリスト

- [x] タイトルをちゃんと設定できている
- [x] Assignerの設定ができている
- [x] Linked issuesの設定ができている
